### PR TITLE
Correct wrong method call in common/yum.py

### DIFF
--- a/testsuite/common/yum.py
+++ b/testsuite/common/yum.py
@@ -156,7 +156,7 @@ def update_repo(repo_file, enabled=True):
         repo_file = '/etc/yum.repos.d/%s' % repo_file
     if not repo_file.endswith('.repo'):
         repo_file = '%s.repo' % repo_file
-    update_yum_config(repo_file, enabled)
+    update_config(repo_file, enabled)
 
 def update_plugin(plugin_conf, enabled=True):
     """Enables or disables all sections in Yum plugin config files
@@ -170,4 +170,4 @@ def update_plugin(plugin_conf, enabled=True):
         plugin_conf = '/etc/yum/pluginconf.d/%s' % plugin_conf
     if not plugin_conf.endswith('.conf'):
         plugin_conf = '%s.conf' % plugin_conf
-    update_yum_config(plugin_conf, enabled)
+    update_config(plugin_conf, enabled)

--- a/testsuite/test_audreyvm01register.py
+++ b/testsuite/test_audreyvm01register.py
@@ -127,6 +127,7 @@ def test_setup_tunnel(audreyvars, katello_discoverable, tunnel_requested):
         # variable
         assert audreyvars.has_key("KATELLO_PORT")
         os.environ["AUDREY_VAR_KATELLO_REGISTER_KATELLO_PORT"] = os.environ.get("AUDREY_VAR_KATELLO_REGISTER_SSH_TUNNEL_KATELLO_PORT", "8080")
+        global configure_rhsm_tunnel
         configure_rhsm_tunnel = True
     else:
         pytest.skip(msg='Not configuring tunnel')

--- a/testsuite/test_audreyvm01register.py
+++ b/testsuite/test_audreyvm01register.py
@@ -29,6 +29,7 @@ from ConfigParser import ConfigParser
 import glob
 import re
 import subprocess
+import fileinput
 
 configure_rhsm_tunnel = False
 """
@@ -190,6 +191,26 @@ def test_tunnel_rhsm(audreyvars, subscription_manager_version):
         else:
             common.shell.run('subscription-manager config --rhsm.baseurl=%s' % rhsm_baseurl)
             common.shell.run('subscription-manager config --server.port=%s' % server_port)
+
+def test_tunnel_goferd(audreyvars):
+    """This test sets up a GoferD tunnel, if it's desired.
+
+    :param audreyvars: Dict of audrey environment variables
+    :type audreyvars: dict
+
+    :raises: AssertionError
+    """
+    if not configure_rhsm_tunnel:
+        pytest.skip(msg='Not setting up a tunnel')
+    else:
+        plugin_conf = '/etc/gofer/plugins/katelloplugin.conf'
+        assert os.path.isfile(plugin_conf)
+        for line in fileinput.input(plugin_conf, inplace=1):
+            line = line.rstrip('\n')
+            if line.startswith("url=") and line.endswith(":5674"):
+                print line.replace(":5671", ":5674")
+            else:
+                print line
 
 def test_disable_rhui(audreyvars, ec2_deployment):
     """This test disables RHUI, if it's desired.


### PR DESCRIPTION
Looks like we're calling the wrong method name when attempting to update yum configuration files.  This pull request will fix that.

Thanks,
James
